### PR TITLE
Shrink speedtest docker images

### DIFF
--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -1,5 +1,20 @@
-FROM node:12
-MAINTAINER Jonas Friedmann <j@frd.mn>
+FROM debian:10-slim AS get-speedtest
+
+RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-release -y
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+RUN echo "deb https://ookla.bintray.com/debian $(lsb_release -sc) main" | tee  /etc/apt/sources.list.d/speedtest.list
+RUN apt-get update
+RUN apt-get install speedtest
+
+FROM alpine as install-dependencies
+RUN apk add --no-cache npm
+WORKDIR /build
+COPY . .
+RUN npm ci
+
+FROM alpine as prod-stage
+RUN apk add --no-cache nodejs
+LABEL maintainer="Jonas Friedmann <j@frd.mn>"
 
 WORKDIR /usr/src/app
 
@@ -8,14 +23,7 @@ ENV INFLUXDB_DB="speedtest" \
     SPEEDTEST_HOST="local" \
     SPEEDTEST_INTERVAL=3600
 
-RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-core software-properties-common -y
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-RUN add-apt-repository "deb https://ookla.bintray.com/debian $(lsb_release -sc) main"
-RUN apt-get update
-RUN apt-get install speedtest
-
-
-COPY . .
-RUN npm ci
-
 CMD [ "node", "index.js" ]
+
+COPY --from=get-speedtest /usr/bin/speedtest /usr/bin/speedtest
+COPY --from=install-dependencies /build .


### PR DESCRIPTION
Shrink the speedtest docker image size from 1.14GB to 40.1MB.
```sh
λ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
speedtest-new       latest              883b24ae3d7f        34 seconds ago      40.1MB
speedtest-old       latest              b29f8649b1ff        3 minutes ago       1.14GB
```